### PR TITLE
Fix set execute permission on gradlew in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM docker.io/library/eclipse-temurin:23-jdk-alpine AS builder
 
 WORKDIR /src/advshop
 COPY . .
-RUN ./gradlew clean bootJar
+RUN chmod +x gradlew && ./gradlew clean bootJar
 
 FROM docker.io/library/eclipse-temurin:23-jre-alpine AS runner
 


### PR DESCRIPTION
- Added 'chmod +x gradlew' before running the bootJar task.
- Resolves the "Permission denied" error during the Docker build.